### PR TITLE
add react 17 to peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "standard-version": "^7.0.0"
   },
   "peerDependencies": {
-    "react": "^0.14 || ^15 || ^16"
+    "react": "^0.14 || ^15 || ^16 || ^17"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Add React 17 in order to prevent warnings when installing with newer version of react